### PR TITLE
scripts to delete Bridge and Synapse data for a given study and date

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <version>1.0</version>
 
     <properties>
+        <aws.version>1.11.22</aws.version>
         <java.version>1.8</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -15,6 +16,16 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-dynamodb</artifactId>
+            <version>${aws.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,11 @@
             <version>19.0</version>
         </dependency>
         <dependency>
+            <groupId>com.jcabi</groupId>
+            <artifactId>jcabi-aspects</artifactId>
+            <version>0.22.5</version>
+        </dependency>
+        <dependency>
             <groupId>com.stormpath.sdk</groupId>
             <artifactId>stormpath-sdk-api</artifactId>
             <version>${stormpath.version}</version>
@@ -42,9 +47,14 @@
             <version>${stormpath.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.aspectj</groupId>
+            <artifactId>aspectjrt</artifactId>
+            <version>1.8.9</version>
+        </dependency>
+        <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>synapseJavaClient</artifactId>
-            <version>123.0</version>
+            <version>154.0</version>
         </dependency>
     </dependencies>
 
@@ -55,4 +65,33 @@
             <url>http://sagebionetworks.artifactoryonline.com/sagebionetworks/libs-releases-local</url>
         </repository>
     </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>aspectj-maven-plugin</artifactId>
+                <version>1.8</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <complianceLevel>${java.version}</complianceLevel>
+                    <aspectLibraries>
+                        <aspectLibrary>
+                            <groupId>com.jcabi</groupId>
+                            <artifactId>jcabi-aspects</artifactId>
+                        </aspectLibrary>
+                    </aspectLibraries>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/org/sagebionetworks/bridge/scripts/PurgeStudySynapseDataByDate.java
+++ b/src/main/java/org/sagebionetworks/bridge/scripts/PurgeStudySynapseDataByDate.java
@@ -1,0 +1,199 @@
+package org.sagebionetworks.bridge.scripts;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.dynamodbv2.document.DynamoDB;
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.StringUtils;
+import org.joda.time.LocalDate;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.SynapseClientImpl;
+import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.repo.model.table.ColumnType;
+import org.sagebionetworks.repo.model.table.Row;
+import org.sagebionetworks.repo.model.table.RowSelection;
+import org.sagebionetworks.repo.model.table.SelectColumn;
+import org.sagebionetworks.repo.model.table.TableEntity;
+
+import org.sagebionetworks.bridge.synapse.SynapseTableIterator;
+
+public class PurgeStudySynapseDataByDate {
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final int SLEEP_TIME_MILLIS = 1000;
+
+    private static DynamoDB ddbClient;
+    private static boolean debug;
+    private static SynapseClient synapseClient;
+    private static Table synapseMetaTablesDdbTable;
+    private static Table synapseTablesDdbTable;
+
+    public static void main(String[] args) throws IOException {
+        if (args.length != 4) {
+            System.out.println("Usage: PurgeStudySynapseDataByDate [path to config JSON] [study ID] " +
+                    "[date (YYYY-MM-DD)] [debug/release]");
+            return;
+        }
+
+        if ("debug".equals(args[3])) {
+            System.out.println("Running in DEBUG mode");
+            debug = true;
+        } else if ("release".equals(args[3])) {
+            System.out.println("Running in RELEASE mode");
+            System.out.println("IMPORTANT: This will delete data from Synapse");
+            debug = false;
+        } else {
+            System.out.println("Must specify debug or release");
+            return;
+        }
+
+        init(args[0]);
+        execute(args[1], LocalDate.parse(args[2]));
+        cleanup();
+
+        System.out.println("Done");
+    }
+
+    public static void init(String configPath) throws IOException {
+        // load config JSON
+        JsonNode configNode = JSON_MAPPER.readTree(new File(configPath));
+
+        // init ddb
+        String ddbPrefix = configNode.get("ddbPrefix").textValue();
+        ddbClient = new DynamoDB(new AmazonDynamoDBClient());
+        synapseMetaTablesDdbTable = ddbClient.getTable(ddbPrefix + "SynapseMetaTables");
+        synapseTablesDdbTable = ddbClient.getTable(ddbPrefix + "SynapseTables");
+
+        // init Synapse client
+        String synapseUser = configNode.get("synapseUser").textValue();
+        String synapseApiKey = configNode.get("synapseApiKey").textValue();
+        synapseClient = new SynapseClientImpl();
+        synapseClient.setUserName(synapseUser);
+        synapseClient.setApiKey(synapseApiKey);
+    }
+
+    public static void cleanup() {
+        ddbClient.shutdown();
+    }
+
+    public static void execute(String studyId, LocalDate date) {
+        // iterate over all Synapse tables
+        Iterable<Item> synapseMetaTablesDdbIter = synapseMetaTablesDdbTable.scan();
+        for (Item oneSynapseMetaTable : synapseMetaTablesDdbIter) {
+            String tableName = oneSynapseMetaTable.getString("tableName");
+            String synapseTableId = oneSynapseMetaTable.getString("tableId");
+            handleTable(studyId, date, tableName, synapseTableId);
+            System.out.println();
+        }
+
+        Iterable<Item> synapseTablesDdbIter = synapseTablesDdbTable.scan();
+        for (Item oneSynapseTable : synapseTablesDdbIter) {
+            String schemaKey = oneSynapseTable.getString("schemaKey");
+            String synapseTableId = oneSynapseTable.getString("tableId");
+            handleTable(studyId, date, schemaKey, synapseTableId);
+            System.out.println();
+        }
+    }
+
+    public static void handleTable(String studyId, LocalDate date, String tableKey, String synapseTableId) {
+        // sleep to avoid browning out DDB or Synapse
+        try {
+            Thread.sleep(SLEEP_TIME_MILLIS);
+        } catch (InterruptedException ex) {
+            System.err.println("Interrupted while sleeping: " + ex.getMessage());
+            ex.printStackTrace();
+        }
+
+        if (!tableKey.startsWith(studyId)) {
+            if (debug) {
+                System.out.println("Skipping table " + tableKey);
+            }
+            return;
+        }
+
+        System.out.println("Processing table tableKey=" + tableKey + ", synapseTableId=" + synapseTableId);
+        try {
+            // get table from Synapse
+            TableEntity synapseTable = synapseClient.getEntity(synapseTableId, TableEntity.class);
+            if (synapseTable == null) {
+                System.out.println("Couldn't find table tableKey=" + tableKey + ", synapseTableId=" + synapseTableId);
+                return;
+            }
+
+            // query and iterate over all records in the given date
+            SynapseTableIterator tableRowIter = new SynapseTableIterator(synapseClient, "SELECT * FROM " +
+                    synapseTableId + " WHERE uploadDate = '" + date.toString() + "'", synapseTableId);
+
+            // get headers
+            List<SelectColumn> headerList = tableRowIter.getHeaders();
+            int numCols = headerList.size();
+
+            // check for recordId column and file handle columns
+            Integer recordIdColIdx = null;
+            List<Integer> fileHandleColIdxList = new ArrayList<>();
+            for (int i = 0; i < numCols; i++) {
+                SelectColumn oneHeader = headerList.get(i);
+
+                if ("recordId".equals(oneHeader.getName())) {
+                    recordIdColIdx = i;
+                }
+
+                if (oneHeader.getColumnType() == ColumnType.FILEHANDLEID) {
+                    fileHandleColIdxList.add(i);
+                }
+            }
+
+            // iterate over rows
+            List<Long> rowIdsToDelete = new ArrayList<>();
+            while (tableRowIter.hasNext()) {
+                Row oneRow = tableRowIter.next();
+                List<String> rowValueList = oneRow.getValues();
+                String recordId = null;
+                if (recordIdColIdx != null) {
+                    recordId = rowValueList.get(recordIdColIdx);
+                }
+                rowIdsToDelete.add(oneRow.getRowId());
+                System.out.println("Found record for table " + tableKey + ", recordId=" + recordId);
+
+                try {
+                    // find all file handle IDs
+                    for (int oneFileHandleColIdx : fileHandleColIdxList) {
+                        String fileHandleId = rowValueList.get(oneFileHandleColIdx);
+                        if (StringUtils.isNotBlank(fileHandleId)) {
+                            System.out.println("Found file handle for table " + tableKey + ", recordId=" + recordId +
+                                    ", fileHandleId=" + fileHandleId);
+                            if (!debug) {
+                                synapseClient.deleteFileHandle(fileHandleId);
+                            }
+                        }
+                    }
+                } catch (SynapseException | RuntimeException ex) {
+                    System.out.println("Error processing row, tableKey=" + tableKey + ", synapseTableId=" +
+                            synapseTableId + ", recordId=" + recordId + ": " + ex.getMessage());
+                    ex.printStackTrace();
+                }
+            }
+
+            if (!rowIdsToDelete.isEmpty() && !debug) {
+                // delete rows from Synapse table
+                RowSelection rowSelectionToDelete = new RowSelection();
+                rowSelectionToDelete.setEtag(tableRowIter.getEtag());
+                rowSelectionToDelete.setRowIds(rowIdsToDelete);
+                rowSelectionToDelete.setTableId(synapseTableId);
+                synapseClient.deleteRowsFromTable(rowSelectionToDelete);
+
+                System.out.println("Deleted rows from table tableKey=" + tableKey + ", synapseTableId=" +
+                        synapseTableId + ", " + rowIdsToDelete.size() + " rows");
+            }
+        } catch (RuntimeException | SynapseException ex) {
+            System.out.println("Error processing table " + tableKey + ": " + ex.getMessage());
+            ex.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/scripts/PurgeStudyUploadsByDate.java
+++ b/src/main/java/org/sagebionetworks/bridge/scripts/PurgeStudyUploadsByDate.java
@@ -1,0 +1,167 @@
+package org.sagebionetworks.bridge.scripts;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.dynamodbv2.document.DynamoDB;
+import com.amazonaws.services.dynamodbv2.document.Index;
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.commons.lang.StringUtils;
+import org.joda.time.LocalDate;
+
+public class PurgeStudyUploadsByDate {
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final int SLEEP_TIME_MILLIS = 1000;
+
+    // DDB
+    private static DynamoDB ddbClient;
+    private static boolean debug;
+    private static Index attachmentRecordIdIndex;
+    private static Table attachmentTable;
+    private static Table healthCodeTable;
+    private static Table recordTable;
+    private static Index uploadDateIndex;
+    private static Table uploadTable;
+
+    // S3
+    private static String attachmentBucket;
+    private static AmazonS3Client s3Client;
+    private static String uploadBucket;
+
+    public static void main(String[] args) throws IOException {
+        if (args.length != 4) {
+            System.out.println("Usage: PurgeStudyUploadsByDate [path to config JSON] [study ID] [date (YYYY-MM-DD)] " +
+            "[debug/release]");
+            return;
+        }
+
+        if ("debug".equals(args[3])) {
+            System.out.println("Running in DEBUG mode");
+            debug = true;
+        } else if ("release".equals(args[3])) {
+            System.out.println("Running in RELEASE mode");
+            System.out.println("IMPORTANT: This will delete rows from DDB and files from S3");
+            debug = false;
+        } else {
+            System.out.println("Must specify debug or release");
+            return;
+        }
+
+        init(args[0]);
+        execute(args[1], LocalDate.parse(args[2]));
+        cleanup();
+
+        System.out.println("Done");
+    }
+
+    public static void init(String configPath) throws IOException {
+        // load config JSON
+        JsonNode configNode = JSON_MAPPER.readTree(new File(configPath));
+
+        // init ddb
+        String ddbPrefix = configNode.get("ddbBridgePrefix").textValue();
+        ddbClient = new DynamoDB(new AmazonDynamoDBClient());
+        attachmentTable = ddbClient.getTable(ddbPrefix + "HealthDataAttachment");
+        attachmentRecordIdIndex = attachmentTable.getIndex("recordId-index");
+        healthCodeTable = ddbClient.getTable(ddbPrefix + "HealthCode");
+        recordTable = ddbClient.getTable(ddbPrefix + "HealthDataRecord3");
+        uploadTable = ddbClient.getTable(ddbPrefix + "Upload2");
+        uploadDateIndex = uploadTable.getIndex("uploadDate-index");
+
+        // init S3 client
+        attachmentBucket = configNode.get("attachmentBucket").textValue();
+        s3Client = new AmazonS3Client();
+        uploadBucket = configNode.get("uploadBucket").textValue();
+    }
+
+    public static void cleanup() {
+        ddbClient.shutdown();
+        s3Client.shutdown();
+    }
+
+    public static void execute(String studyId, LocalDate date) {
+        // find all uploads for this date
+        Iterable<Item> uploadsForDateIter = uploadDateIndex.query("uploadDate", date.toString());
+        for (Item oneUpload : uploadsForDateIter) {
+            // sleep to avoid browning out DDB
+            try {
+                Thread.sleep(SLEEP_TIME_MILLIS);
+            } catch (InterruptedException ex) {
+                System.err.println("Interrupted while sleeping: " + ex.getMessage());
+                ex.printStackTrace();
+            }
+
+            String uploadId = oneUpload.getString("uploadId");
+            try {
+                // First step is to re-query the table to get all params.
+                Item fullUpload = uploadTable.getItem("uploadId", uploadId);
+                String healthCode = fullUpload.getString("healthCode");
+
+                // Check healthCode table to verify what study this upload comes from.
+                Item healthCodeToStudy = healthCodeTable.getItem("code", healthCode);
+                String uploadStudyId = healthCodeToStudy.getString("studyIdentifier");
+                if (!studyId.equals(uploadStudyId)) {
+                    if (debug) {
+                        System.out.println("Filtered out uploadId=" + uploadId + ": Upload not in study " + studyId +
+                                ", instead in study " + uploadStudyId);
+                        System.out.println();
+                    }
+                    continue;
+                }
+
+                String recordId = fullUpload.getString("recordId");
+                System.out.println("Found qualifying upload with uploadId=" + uploadId + ", recordId=" + recordId);
+
+                if (StringUtils.isNotBlank(recordId)) {
+                    // Query attachments table by recordId
+                    Iterable<Item> attachmentsForRecordIter = attachmentRecordIdIndex.query("recordId", recordId);
+                    for (Item oneAttachment : attachmentsForRecordIter) {
+                        String attachmentId = oneAttachment.getString("id");
+                        System.out.println("Found attachment for uploadId=" + uploadId + ", recordId=" + recordId +
+                                ", attachmentId=" + attachmentId);
+
+                        if (!debug) {
+                            // Delete from S3 first, then delete from attachments table. This way, if deleting from S3
+                            // fails, we can find the record again through the attachments table.
+
+                            // delete from S3
+                            s3Client.deleteObject(attachmentBucket, attachmentId);
+
+                            // delete from attachments table
+                            attachmentTable.deleteItem("id", attachmentId);
+                        }
+                    }
+                }
+
+                if (!debug) {
+                    // Delete the record before the upload. This way, we can find the record from the upload if
+                    // deleting the record fails. Similarly for the upload in S3.
+
+                    // delete record
+                    if (StringUtils.isNotBlank(recordId)) {
+                        recordTable.deleteItem("id", recordId);
+                    }
+
+                    // delete from S3
+                    s3Client.deleteObject(uploadBucket, uploadId);
+
+                    // delete upload
+                    uploadTable.deleteItem("uploadId", uploadId);
+
+                    System.out.println("Done deleting for uploadId=" + uploadId);
+                }
+            } catch (RuntimeException ex) {
+                System.err.println("Error processing uploadId="  + uploadId + ": " + ex.getMessage());
+                ex.printStackTrace();
+            }
+
+            // Newline for better logging.
+            System.out.println();
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/synapse/SynapseTableIterator.java
+++ b/src/main/java/org/sagebionetworks/bridge/synapse/SynapseTableIterator.java
@@ -1,0 +1,290 @@
+package org.sagebionetworks.bridge.synapse;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.concurrent.TimeUnit;
+
+import com.jcabi.aspects.RetryOnFailure;
+import org.apache.commons.lang.StringUtils;
+import org.sagebionetworks.client.SynapseClient;
+import org.sagebionetworks.client.exceptions.SynapseClientException;
+import org.sagebionetworks.client.exceptions.SynapseException;
+import org.sagebionetworks.client.exceptions.SynapseResultNotReadyException;
+import org.sagebionetworks.repo.model.table.QueryNextPageToken;
+import org.sagebionetworks.repo.model.table.QueryResult;
+import org.sagebionetworks.repo.model.table.QueryResultBundle;
+import org.sagebionetworks.repo.model.table.Row;
+import org.sagebionetworks.repo.model.table.SelectColumn;
+
+/** Helper class to query Synapse tables and iterate over the results, abstracting away pagination. */
+// This doesn't implement Iterator, since Iterator's methods can't throw checked exceptions.
+public class SynapseTableIterator {
+    private static final int ASYNC_QUERY_TIMEOUT_SECONDS = 300;
+
+    // Constructor args.
+    private final SynapseClient synapseClient;
+    private final String synapseTableId;
+
+    // Internal state tracking.
+    private String asyncJobToken;
+    private QueryResult curResult;
+    private int curRowNumInPage = 0;
+    private String etag;
+    private boolean firstPage = true;
+    private List<SelectColumn> headers;
+    private Row nextRow;
+
+    /**
+     * Creates the Synapse table iterator with the specified args.
+     *
+     * @param synapseClient
+     *         synapse client
+     * @param sql
+     *         SQL query to run, defaults to "SELECT * FROM [synapseTableId]"
+     * @param synapseTableId
+     *         synapse table ID to run the query against
+     * @throws SynapseException
+     *         if the synapse call fails
+     */
+    public SynapseTableIterator(SynapseClient synapseClient, String sql, String synapseTableId)
+            throws SynapseException {
+        if (StringUtils.isBlank(sql)) {
+            sql = "SELECT * FROM " + synapseTableId;
+        }
+
+        this.synapseClient = synapseClient;
+        this.synapseTableId = synapseTableId;
+        this.asyncJobToken = queryTableAsyncStartWithRetry(sql);
+    }
+
+    /**
+     * Returns true if the iterator has additional elements. Does not advance the iterator.
+     *
+     * @return true if the iterator has additional elements.
+     * @throws SynapseException
+     *         if the underlying Synapse call fails
+     */
+    // Checks if a row is available, and if so, loads it into nextRow.
+    public boolean hasNext() throws SynapseException {
+        if (nextRow != null) {
+            // Next row is already loaded and ready.
+            return true;
+        }
+
+        if (asyncJobToken != null) {
+            // We have a page to fetch.
+            fetchNextPage();
+
+            // Once we've fetched the page, wipe the asyncJobToken so we don't try to fetch it again.
+            asyncJobToken = null;
+
+            // If we just fetched a page with no rows, then this means we've hit the end of the stream. Return false.
+            if (curResult.getQueryResults().getRows().isEmpty()) {
+                curResult = null;
+                return false;
+            }
+        }
+
+        if (curResult != null) {
+            List<Row> rowList = curResult.getQueryResults().getRows();
+            // This should be fine, since we always wipe the curResults when we get to the end of the page.
+            nextRow = rowList.get(curRowNumInPage);
+
+            // Advance the row num.
+            curRowNumInPage++;
+            if (curRowNumInPage == rowList.size()) {
+                // If that was the last row and we have a next page token, go ahead and set up the
+                // next page.
+                QueryNextPageToken nextPageToken = curResult.getNextPageToken();
+                if (nextPageToken != null) {
+                    asyncJobToken = queryTableNextPageAsyncStartWithRetry(nextPageToken.getToken());
+                }
+
+                // Wipe out the curResult, since we're done with it. This allows the iterator to remember that we
+                // need to fetch the next page. Also, the row num since we're in a new page.
+                curResult = null;
+                curRowNumInPage = 0;
+            }
+
+            return true;
+        }
+
+        // This is the end.
+        return false;
+    }
+
+    /**
+     * Returns the next element in the iterator. Throws a NoSuchElementException if no such element exists.
+     *
+     * @return the next element in the iterator
+     * @throws NoSuchElementException
+     *         if no such element exists
+     * @throws SynapseException
+     *         if an underlying Synapse call fails
+     */
+    // Call hasNext() first to check if we have a row or load the next row if needed.
+    public Row next() throws NoSuchElementException, SynapseException {
+        if (hasNext()) {
+            // clear the nextRow, so hasNext() knows to load the next one
+            Row retVal = nextRow;
+            nextRow = null;
+            return retVal;
+        } else {
+            throw new NoSuchElementException();
+        }
+    }
+
+    /**
+     * Returns the etag from the first page of results. This doesn't get updated with subsequent page fetches, so if
+     * there's an intravening update, the etag will reflect that the query results are outdated.
+     *
+     * @return the etag from the query
+     * @throws SynapseException
+     *         if an underlying Synapse call fails
+     */
+    public String getEtag() throws SynapseException {
+        if (etag == null) {
+            // Force initialization by calling hasNext(), which fetches the page. This is safe, because hasNext() will
+            // only fetch the page if it hasn't already been fetched.
+            hasNext();
+        }
+        return etag;
+    }
+
+    /**
+     * Returns the headers (selected columns) from the first page of results. This will remain the same for all
+     * subsequent pages.
+     *
+     * @return list of headers (selected columns
+     * @throws SynapseException
+     *         if an underlying Synapse call fails
+     */
+    public List<SelectColumn> getHeaders() throws SynapseException {
+        if (headers == null) {
+            // Force initialization by calling hasNext(), which fetches the page. This is safe, because hasNext() will
+            // only fetch the page if it hasn't already been fetched.
+            hasNext();
+        }
+        return headers;
+    }
+
+    private void fetchNextPage() throws SynapseException {
+        // poll asyncGet until success or timeout
+        boolean success = false;
+        for (int sec = 0; sec < ASYNC_QUERY_TIMEOUT_SECONDS; sec++) {
+            // sleep for 1 sec
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ex) {
+                // noop
+            }
+
+            // poll
+            if (firstPage) {
+                // This is the first page, so we call bundle get instead of next page get.
+                QueryResultBundle resultBundle = queryTableAsyncGetWithRetry(asyncJobToken);
+                if (resultBundle == null) {
+                    // not ready, loop around again
+                    continue;
+                }
+                curResult = resultBundle.getQueryResult();
+
+                // fetch etag
+                etag = curResult.getQueryResults().getEtag();
+                headers = curResult.getQueryResults().getHeaders();
+
+                // This is no longer the first page.
+                firstPage = false;
+            } else {
+                // We're getting a next page.
+                curResult = queryTableNextPageAsyncGetWithRetry(asyncJobToken);
+                if (curResult == null) {
+                    // not ready, loop around again
+                    continue;
+                }
+            }
+
+            // If we made it this far, we've successfully fetched the page.
+            success = true;
+            break;
+        }
+
+        if (!success) {
+            throw new SynapseClientException("Timed out querying table " + synapseTableId);
+        }
+    }
+
+    /**
+     * Kicks off an async SQL query against the specified table. This uses jcabi-retry to retry the call on failure.
+     *
+     * @param sql
+     *         SQL to run against table
+     * @return the async job token
+     * @throws SynapseException
+     *         if the Synapse call fails
+     */
+    @RetryOnFailure(attempts = 5, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    private String queryTableAsyncStartWithRetry(String sql) throws SynapseException {
+        return synapseClient.queryTableEntityBundleAsyncStart(sql, null, null, true, SynapseClient.QUERY_PARTMASK,
+                synapseTableId);
+    }
+
+    /**
+     * Fetches the result of an async query, or returns null if the result is not ready. This uses jcabi-retry to
+     * retry the call on failure.
+     *
+     * @param asyncJobToken
+     *         async job token of the result to be fetched
+     * @return the result of the async query, or null if the result is not ready
+     * @throws SynapseException
+     *         if the Synapse call fails
+     */
+    @RetryOnFailure(attempts = 5, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    private QueryResultBundle queryTableAsyncGetWithRetry(String asyncJobToken) throws SynapseException {
+        try {
+            return synapseClient.queryTableEntityBundleAsyncGet(asyncJobToken, synapseTableId);
+        } catch (SynapseResultNotReadyException ex) {
+            // catch this and return null so we don't retry on "not ready"
+            return null;
+        }
+    }
+
+    /**
+     * Asynchronously gets the next page of the query for the specified table. This uses jcabi-retry to retry the call
+     * on failure.
+     *
+     * @param nextPageToken
+     *         token used to fetch the next page
+     * @return the async job token
+     * @throws SynapseException
+     *         if the Synapse call fails
+     */
+    @RetryOnFailure(attempts = 5, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    private String queryTableNextPageAsyncStartWithRetry(String nextPageToken) throws SynapseException {
+        return synapseClient.queryTableEntityNextPageAsyncStart(nextPageToken, synapseTableId);
+    }
+
+    /**
+     * Fetches the result of an async query next page, or returns null if the result is not ready. This uses
+     * jcabi-retry to retry the call on failure.
+     *
+     * @param asyncJobToken
+     *         async job token of the result to be fetched
+     * @return the result of the async query, or null if the result is not ready
+     * @throws SynapseException
+     *         if the Synapse call fails
+     */
+    @RetryOnFailure(attempts = 5, delay = 100, unit = TimeUnit.MILLISECONDS, types = SynapseException.class,
+            randomize = false)
+    private QueryResult queryTableNextPageAsyncGetWithRetry(String asyncJobToken) throws SynapseException {
+        try {
+            return synapseClient.queryTableEntityNextPageAsyncGet(asyncJobToken, synapseTableId);
+        } catch (SynapseResultNotReadyException ex) {
+            // catch this and return null so we don't retry on "not ready"
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
==PurgeStudyUploadsByDate==

Script which deletes all uploads for a study for a given uploadDate. We use uploadDate and not (for example) requestedOn, because a lot of these uploads predate requestedOn. Similarly, a lot of these uploads predate studyId in the uploads table, so we need to cross-ref the healthcode to determine study.

The script:
- Queries uploads by uploadDate.
- Cross-refs healthcode to filter out uploads not in the target study.
- Finds the health data record and attachments associated with the upload.
- Deletes the upload, health data record, and attachments from DDB.
- Deletes the upload and attachments from S3. (Records have no S3 equivalent.)

Also includes a debug/release script so we can verify that we're deleting the right things before we actually delete them.

Testing done:
- Upload not in the target study.
- Upload without a record.
- Upload with a record with no attachments.
- Upload with 1 attachment.
- Upload with multiple attachments.

==PurgeStudySynapseDataByDate==

Script which deletes all rows and filehnaldes for a study for a given uploadDate. It has a similar debug flag.

The script:
- Scans BridgeEX's configs to find all tables within a study.
- Queries each Synapse table for a given date.
- Deletes all rows and filehandles for the given date.

Testing done:
- Ignores tables in other studies.
- Tables with no file handles.
- Tables with multiple file handles.
- Rows with with some file handles present, some file handles absent.

==SynapseTableIterator==

Can ignore this file. This is copied from BridgeEX. We'll need to move this to bridge-base or some other shared utils package.
