### PR TITLE
Stormpath to MySQL migration scripts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,19 @@
             <version>${stormpath.version}</version>
         </dependency>
         <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <version>6.0.6</version>
+        </dependency>
+        <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
             <version>1.8.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.sagebionetworks</groupId>
+            <artifactId>bridge-base</artifactId>
+            <version>2.7.6</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks</groupId>
@@ -63,6 +73,11 @@
             <id>sagebionetworks-libs-releases-local</id>
             <name>sagebionetworks-libs-releases-local</name>
             <url>http://sagebionetworks.artifactoryonline.com/sagebionetworks/libs-releases-local</url>
+        </repository>
+        <repository>
+            <id>org-sagebridge-repo-maven-releases</id>
+            <name>org-sagebridge-repo-maven-releases</name>
+            <url>https://repo-maven.sagebridge.org/</url>
         </repository>
     </repositories>
 

--- a/src/main/java/org/sagebionetworks/bridge/scripts/StormpathToMySqlMigration.java
+++ b/src/main/java/org/sagebionetworks/bridge/scripts/StormpathToMySqlMigration.java
@@ -131,6 +131,7 @@ public class StormpathToMySqlMigration {
         }
     }
 
+    @SuppressWarnings("ConstantConditions")
     private static void execute() throws IOException, SQLException {
         // Metrics
         int numAccounts = 0;
@@ -314,33 +315,33 @@ public class StormpathToMySqlMigration {
         //noinspection StringBufferReplaceableByString
         StringBuilder queryBuilder = new StringBuilder();
         queryBuilder.append("insert into Accounts (id, studyId, email, createdOn, healthCode, healthId, modifiedOn, " +
-                "firstName, lastName, passwordAlgorithm, passwordHash, passwordModifiedOn, status) values ('");
-        queryBuilder.append(accountNode.get("id").textValue());
-        queryBuilder.append("', '");
-        queryBuilder.append(accountNode.get("studyId").textValue());
-        queryBuilder.append("', '");
-        queryBuilder.append(accountNode.get("email").textValue());
-        queryBuilder.append("', ");
-        queryBuilder.append(accountNode.get("createdOn").longValue());
-        queryBuilder.append(", '");
-        queryBuilder.append(accountNode.get("healthCode").textValue());
-        queryBuilder.append("', '");
-        queryBuilder.append(accountNode.get("healthId").textValue());
-        queryBuilder.append("', ");
-        queryBuilder.append(accountNode.get("modifiedOn").longValue());
-        queryBuilder.append(", '");
-        queryBuilder.append(accountNode.get("firstName").textValue());
-        queryBuilder.append("', '");
-        queryBuilder.append(accountNode.get("lastName").textValue());
-        queryBuilder.append("', '");
-        queryBuilder.append(accountNode.get("passwordAlgorithm").textValue());
-        queryBuilder.append("', '");
-        queryBuilder.append(accountNode.get("passwordHash").textValue());
-        queryBuilder.append("', ");
-        queryBuilder.append(accountNode.get("passwordModifiedOn").longValue());
-        queryBuilder.append(", '");
-        queryBuilder.append(accountNode.get("status").textValue());
-        queryBuilder.append("')");
+                "firstName, lastName, passwordAlgorithm, passwordHash, passwordModifiedOn, status) values (");
+        queryBuilder.append(serializeJsonTextField(accountNode, "id"));
+        queryBuilder.append(", ");
+        queryBuilder.append(serializeJsonTextField(accountNode, "studyId"));
+        queryBuilder.append(", ");
+        queryBuilder.append(serializeJsonTextField(accountNode, "email"));
+        queryBuilder.append(", ");
+        queryBuilder.append(getJsonNumberField(accountNode, "createdOn"));
+        queryBuilder.append(", ");
+        queryBuilder.append(serializeJsonTextField(accountNode, "healthCode"));
+        queryBuilder.append(", ");
+        queryBuilder.append(serializeJsonTextField(accountNode, "healthId"));
+        queryBuilder.append(", ");
+        queryBuilder.append(getJsonNumberField(accountNode, "modifiedOn"));
+        queryBuilder.append(", ");
+        queryBuilder.append(serializeJsonTextField(accountNode, "firstName"));
+        queryBuilder.append(", ");
+        queryBuilder.append(serializeJsonTextField(accountNode, "lastName"));
+        queryBuilder.append(", ");
+        queryBuilder.append(serializeJsonTextField(accountNode, "passwordAlgorithm"));
+        queryBuilder.append(", ");
+        queryBuilder.append(serializeJsonTextField(accountNode, "passwordHash"));
+        queryBuilder.append(", ");
+        queryBuilder.append(getJsonNumberField(accountNode, "passwordModifiedOn"));
+        queryBuilder.append(", ");
+        queryBuilder.append(serializeJsonTextField(accountNode, "status"));
+        queryBuilder.append(")");
         return queryBuilder.toString();
     }
 
@@ -379,41 +380,26 @@ public class StormpathToMySqlMigration {
             JsonNode consentListForSubpop = consentsBySubpopEntry.getValue();
 
             for (JsonNode oneConsent : consentListForSubpop) {
+                //noinspection StringBufferReplaceableByString
                 StringBuilder valueBuilder = new StringBuilder();
                 valueBuilder.append("('");
                 valueBuilder.append(accountId);
                 valueBuilder.append("', '");
                 valueBuilder.append(subpopGuid);
                 valueBuilder.append("', ");
-                valueBuilder.append(oneConsent.get("signedOn").longValue());
-                valueBuilder.append(", '");
-                valueBuilder.append(oneConsent.get("birthdate").textValue());
-                valueBuilder.append("', ");
-                valueBuilder.append(oneConsent.get("consentCreatedOn").longValue());
-                valueBuilder.append(", '");
-                valueBuilder.append(oneConsent.get("name").textValue());
-                valueBuilder.append("', ");
-                if (oneConsent.has("imageData")) {
-                    valueBuilder.append("'");
-                    valueBuilder.append(oneConsent.get("imageData").textValue());
-                    valueBuilder.append("'");
-                } else {
-                    valueBuilder.append("null");
-                }
+                valueBuilder.append(getJsonNumberField(oneConsent,"signedOn"));
                 valueBuilder.append(", ");
-                if (oneConsent.has("imageMimeType")) {
-                    valueBuilder.append("'");
-                    valueBuilder.append(oneConsent.get("imageMimeType").textValue());
-                    valueBuilder.append("'");
-                } else {
-                    valueBuilder.append("null");
-                }
+                valueBuilder.append(serializeJsonTextField(oneConsent, "birthdate"));
                 valueBuilder.append(", ");
-                if (oneConsent.has("withdrewOn")) {
-                    valueBuilder.append(oneConsent.get("withdrewOn").longValue());
-                } else {
-                    valueBuilder.append("null");
-                }
+                valueBuilder.append(getJsonNumberField(oneConsent, "consentCreatedOn"));
+                valueBuilder.append(", ");
+                valueBuilder.append(serializeJsonTextField(oneConsent, "name"));
+                valueBuilder.append(", ");
+                valueBuilder.append(serializeJsonTextField(oneConsent, "imageData"));
+                valueBuilder.append(", ");
+                valueBuilder.append(serializeJsonTextField(oneConsent, "imageMimeType"));
+                valueBuilder.append(", ");
+                valueBuilder.append(getJsonNumberField(oneConsent, "withdrewOn"));
                 valueBuilder.append(")");
                 valueList.add(valueBuilder.toString());
             }
@@ -431,5 +417,23 @@ public class StormpathToMySqlMigration {
         }
 
         return "insert into AccountRoles (accountId, role) values " + SQL_VALUES_JOINER.join(valueList);
+    }
+
+    private static String serializeJsonTextField(JsonNode parent, String key) {
+        JsonNode child = parent.get(key);
+        if (child != null && !child.isNull()) {
+            return "'" + child.textValue() + "'";
+        } else {
+            return null;
+        }
+    }
+
+    private static Long getJsonNumberField(JsonNode parent, String key) {
+        JsonNode child = parent.get(key);
+        if (child != null && !child.isNull()) {
+            return child.longValue();
+        } else {
+            return null;
+        }
     }
 }

--- a/src/main/java/org/sagebionetworks/bridge/scripts/StormpathToMySqlMigration.java
+++ b/src/main/java/org/sagebionetworks/bridge/scripts/StormpathToMySqlMigration.java
@@ -1,0 +1,435 @@
+package org.sagebionetworks.bridge.scripts;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Joiner;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.HashMultiset;
+import com.google.common.collect.Multiset;
+import com.google.common.util.concurrent.RateLimiter;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+// After running TransformStormpathAccounts, run this script.
+// To execute:
+// mvn compile exec:java -Dexec.mainClass=org.sagebionetworks.bridge.scripts.StormpathToMySqlMigration -Dexec.args=[path to config file]
+public class StormpathToMySqlMigration {
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final DateTimeZone LOCAL_TIME_ZONE = DateTimeZone.forID("America/Los_Angeles");
+    private static final int LOG_PERIOD = 1000;
+    private static final Joiner SQL_VALUES_JOINER = Joiner.on(", ");
+
+    // Rate limiter of 10 accounts per second seems reasonable.
+    private static final RateLimiter RATE_LIMITER = RateLimiter.create(10.0);
+
+    private static Path accountsRootPath;
+    private static final Set<String> accountWhitelist = new HashSet<>();
+    private static final Set<String> envSet = new HashSet<>();
+    private static final Map<String, Connection> mySqlConnectionsByEnv = new HashMap<>();
+
+    public static void main(String[] args) throws IOException, SQLException {
+        // input params
+        if (args.length != 1){
+            System.out.println("Usage: StormpathToMySqlMigration [config file]");
+            return;
+        }
+        String configFilePath = args[0];
+
+        // This is to make sure whatever script runs this Java application is properly capturing stdout and stderr and
+        // sending them to the logs
+        System.out.println("Verifying stdout...");
+        System.err.println("Verifying stderr...");
+
+        // init and execute
+        //noinspection finally
+        try {
+            init(configFilePath);
+            execute();
+            shutdown();
+        } catch (Exception ex) {
+            System.err.println("ERROR " + ex.getMessage());
+            ex.printStackTrace();
+        } finally {
+            // For whatever reason, something here keeps the JVM alive even after we shut everything down. Force close the
+            // application.
+            System.out.println("Exiting...");
+            System.exit(0);
+        }
+    }
+
+    private static void init(String configFilePath) throws IOException, SQLException {
+        System.out.println("Initializing...");
+
+        // load config, which is a JSON file
+        JsonNode configNode = JSON_MAPPER.readTree(new File(configFilePath));
+
+        // This is the output of the Transform scripts, but the input of the Migration script.
+        String transformOutputDirPath = configNode.get("outputDirPath").textValue();
+        accountsRootPath = Paths.get(transformOutputDirPath, "accounts");
+
+        // get list of envs
+        JsonNode envListNode = configNode.get("envs");
+        for (JsonNode oneEnvNode : envListNode) {
+            envSet.add(oneEnvNode.textValue());
+        }
+
+        // account whitelist, also used for testing
+        if (configNode.has("accountWhitelist")) {
+            JsonNode accountWhitelistNode = configNode.get("accountWhitelist");
+            for (JsonNode oneAccountId : accountWhitelistNode) {
+                accountWhitelist.add(oneAccountId.textValue());
+            }
+        }
+
+        // config MySQL connections
+        JsonNode mySqlConnectionsByEnvNode = configNode.get("mySqlConnectionsByEnv");
+        for (String oneEnv : envSet) {
+            JsonNode oneConnectionNode = mySqlConnectionsByEnvNode.get(oneEnv);
+            String url = oneConnectionNode.get("url").textValue();
+            String username = oneConnectionNode.get("username").textValue();
+            String password = oneConnectionNode.get("password").textValue();
+
+            // This fixes a timezone bug in the MySQL Connector/J
+            url = url + "?serverTimezone=UTC";
+
+            // Append SSL props to URL if needed
+            boolean useSsl = oneConnectionNode.get("useSsl").booleanValue();
+            if (useSsl) {
+                url = url + "&requireSSL=true&useSSL=true&verifyServerCertificate=true";
+            }
+
+            // Connect to DB
+            Connection oneConnection = DriverManager.getConnection(url, username, password);
+            mySqlConnectionsByEnv.put(oneEnv, oneConnection);
+        }
+    }
+
+    private static void shutdown() throws SQLException {
+        // Close MySQL connection.
+        for (Connection oneConnection : mySqlConnectionsByEnv.values()) {
+            oneConnection.close();
+        }
+    }
+
+    private static void execute() throws IOException, SQLException {
+        // Metrics
+        int numAccounts = 0;
+        int numInserted = 0;
+        int numDeleted = 0;
+        int numSkipped = 0;
+        Multiset<String> numAccountsByEnv = HashMultiset.create(envSet.size());
+
+        // Read transformed accounts and upload them to MySQL.
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        try (Stream<Path> accountPathStream = getPathStream()) {
+            Iterator<Path> accountPathIter = accountPathStream.iterator();
+            while (accountPathIter.hasNext()) {
+                Path oneAccountPath = accountPathIter.next();
+                try {
+                    JsonNode accountNode = JSON_MAPPER.readTree(oneAccountPath.toFile());
+                    String env = accountNode.get("env").textValue();
+                    String accountId = accountNode.get("id").textValue();
+                    long jsonModifiedOn = accountNode.get("modifiedOn").longValue();
+
+                    // env whitelist - We ended up putting accounts for all 4 envs in the same directory to make it
+                    // easier to implement the account whitelist. It doesn't matter that much, since our test data set
+                    // is small, and our prod data set is mostly in the prod env anyway.
+                    if (!envSet.contains(env)) {
+                        continue;
+                    }
+                    numAccountsByEnv.add(env);
+
+                    if (numAccounts % LOG_PERIOD == 0) {
+                        System.out.println(DateTime.now(LOCAL_TIME_ZONE) + ": " + numAccounts +
+                                " accounts processed in " + stopwatch.elapsed(TimeUnit.SECONDS) + " seconds...");
+                    }
+                    numAccounts++;
+
+                    // Similarly, rate limit, also after env whitelist check.
+                    RATE_LIMITER.acquire();
+
+                    // This is not the most efficient way to use JDBC. However, the code is simple, and doing it one
+                    // query at a time allows us to log something at the time an error happens, rather than later on if
+                    // doing a batch request. Plus, this code will be defunct after Aug 17 after the Stormpath
+                    // migration is complete and irreversible.
+
+                    Connection mySqlConnection = mySqlConnectionsByEnv.get(env);
+
+                    // Determine if an account already exists and when the last time it was updated.
+                    boolean hasResult;
+                    Long sqlModifiedOn = null;
+                    try (Statement selectStatement = mySqlConnection.createStatement();
+                            ResultSet selectResultSet = selectStatement.executeQuery("select modifiedOn from " +
+                                    "Accounts where id='" + accountId + "'")) {
+                        // id is a primary key, so there should only be at most one
+                        hasResult = selectResultSet.first();
+                        if (hasResult) {
+                            sqlModifiedOn = selectResultSet.getLong("modifiedOn");
+                        }
+                    }
+
+                    if (hasResult) {
+                        if (sqlModifiedOn >= jsonModifiedOn) {
+                            // If the result exists and is up-to-date, skip.
+                            numSkipped++;
+                            continue;
+                        } else {
+                            // The result set exists and is older than the JSON account info. Delete the old row and
+                            // insert new ones. This is certainly not the most efficient way to update SQL, but this
+                            // code is simpler than trying to query across 4 tables and figuring out which rows to
+                            // update and how.
+                            //
+                            // Note: Just delete the row from Accounts. Foreign key constraints and CASCADE ON DELETE
+                            // will take care of the rest.
+                            try (Statement deleteStatement = mySqlConnection.createStatement()) {
+                                int rowsDeleted = deleteStatement.executeUpdate("delete from Accounts where id='" +
+                                        accountId + "'");
+                                if (rowsDeleted != 1) {
+                                    throw new IllegalStateException("Attempted to delete 1 row for account ID " +
+                                            accountId + ", actually deleted " + rowsDeleted);
+                                }
+                            }
+
+                            // If we found an outdated row in MySQL, this means our Migration Auth Dao is failing to
+                            // keep the account info up-to-date. Log, so we can determine how often this is happening
+                            // and fix as appropriate.
+                            System.out.println("WARN Found outdated account ID " + accountId);
+
+                            // Metrics
+                            numDeleted++;
+                        }
+                    }
+
+                    // At this point, there's definitely no MySQL entry for the account. Transform the account info
+                    // into SQL statements and insert.
+
+                    // insert into Accounts
+                    String insertIntoAccountsQuery = makeInsertIntoAccountsQuery(accountNode);
+                    try (Statement insertIntoAccountsStatement = mySqlConnection.createStatement()) {
+                        int rowsInserted = insertIntoAccountsStatement.executeUpdate(insertIntoAccountsQuery);
+                        if (rowsInserted != 1) {
+                            throw new IllegalStateException("Attempted to insert 1 row into Accounts for account ID " +
+                                    accountId + ", actally inserted " + rowsInserted);
+                        }
+                    }
+
+                    // insert into AccountAttributes
+                    JsonNode attributesNode = accountNode.get("attributes");
+                    if (attributesNode != null && !attributesNode.isNull() && attributesNode.size() > 0) {
+                        int numAttributes = attributesNode.size();
+                        String insertIntoAttributesQuery = makeInsertIntoAttributesQuery(accountId, attributesNode);
+                        try (Statement insertIntoAttributesStatement = mySqlConnection.createStatement()) {
+                            int rowsInserted = insertIntoAttributesStatement.executeUpdate(insertIntoAttributesQuery);
+                            if (rowsInserted != numAttributes) {
+                                throw new IllegalStateException("Attempted to insert " + numAttributes + " rows " +
+                                        "into AccountAttributes for account ID " + accountId + ", actually inserted " +
+                                        rowsInserted);
+                            }
+                        }
+                    }
+
+                    // insert into AccountConsents
+                    JsonNode consentsBySubpop = accountNode.get("consents");
+                    int numConsents = countConsents(consentsBySubpop);
+                    if (numConsents > 0) {
+                        String insertIntoConsentsQuery = makeInsertIntoConsentsQuery(accountId, consentsBySubpop);
+                        try (Statement insertIntoConsentsStatement = mySqlConnection.createStatement()) {
+                            int rowsInserted = insertIntoConsentsStatement.executeUpdate(insertIntoConsentsQuery);
+                            if (rowsInserted != numConsents) {
+                                throw new IllegalStateException("Attempted to insert " + numConsents + " rows into " +
+                                        "AccountConsents for account ID " + accountId + ", actually inserted " +
+                                        rowsInserted);
+                            }
+                        }
+                    }
+
+                    // insert into AccountRoles
+                    JsonNode roleListNode = accountNode.get("roles");
+                    if (roleListNode != null && !roleListNode.isNull() && roleListNode.size() > 0) {
+                        int numRoles = roleListNode.size();
+                        String insertIntoRolesQuery = makeInsertIntoRolesQuery(accountId, roleListNode);
+                        try (Statement insertIntoRolesStatement = mySqlConnection.createStatement()) {
+                            int rowsInserted = insertIntoRolesStatement.executeUpdate(insertIntoRolesQuery);
+                            if (rowsInserted != numRoles) {
+                                throw new IllegalStateException("Attempted to insert " + numRoles + " rows into " +
+                                        "AccountRoles for account ID " + accountId + ", actually inserted " +
+                                        rowsInserted);
+                            }
+                        }
+                    }
+
+                    numInserted++;
+                } catch (Exception ex) {
+                    System.err.println("ERROR Error processing account file " + oneAccountPath.toString() + ": " +
+                            ex.getMessage());
+                    ex.printStackTrace();
+                }
+            }
+        }
+
+        // timing
+        System.out.println(DateTime.now(LOCAL_TIME_ZONE) + ": " + numAccounts + " accounts processed in " +
+                stopwatch.elapsed(TimeUnit.SECONDS) + " seconds...");
+
+        // metrics
+        System.out.println("# total accounts processed: " + numAccounts);
+        System.out.println("# up-to-date accounts skipped: " + numSkipped);
+        System.out.println("# outdated accounts deleted: " + numDeleted);
+        System.out.println("# accounts inserted: " + numInserted);
+
+        for (String oneEnv : envSet) {
+            System.out.println("# accounts (" + oneEnv + "): " + numAccountsByEnv.count(oneEnv));
+        }
+    }
+
+    private static Stream<Path> getPathStream() throws IOException {
+        if (!accountWhitelist.isEmpty()) {
+            return accountWhitelist.stream().map(accountId -> accountsRootPath.resolve(accountId + ".json"));
+        } else {
+            return Files.list(accountsRootPath);
+        }
+    }
+
+    private static String makeInsertIntoAccountsQuery(JsonNode accountNode) {
+        //noinspection StringBufferReplaceableByString
+        StringBuilder queryBuilder = new StringBuilder();
+        queryBuilder.append("insert into Accounts (id, studyId, email, createdOn, healthCode, healthId, modifiedOn, " +
+                "firstName, lastName, passwordAlgorithm, passwordHash, passwordModifiedOn, status) values ('");
+        queryBuilder.append(accountNode.get("id").textValue());
+        queryBuilder.append("', '");
+        queryBuilder.append(accountNode.get("studyId").textValue());
+        queryBuilder.append("', '");
+        queryBuilder.append(accountNode.get("email").textValue());
+        queryBuilder.append("', ");
+        queryBuilder.append(accountNode.get("createdOn").longValue());
+        queryBuilder.append(", '");
+        queryBuilder.append(accountNode.get("healthCode").textValue());
+        queryBuilder.append("', '");
+        queryBuilder.append(accountNode.get("healthId").textValue());
+        queryBuilder.append("', ");
+        queryBuilder.append(accountNode.get("modifiedOn").longValue());
+        queryBuilder.append(", '");
+        queryBuilder.append(accountNode.get("firstName").textValue());
+        queryBuilder.append("', '");
+        queryBuilder.append(accountNode.get("lastName").textValue());
+        queryBuilder.append("', '");
+        queryBuilder.append(accountNode.get("passwordAlgorithm").textValue());
+        queryBuilder.append("', '");
+        queryBuilder.append(accountNode.get("passwordHash").textValue());
+        queryBuilder.append("', ");
+        queryBuilder.append(accountNode.get("passwordModifiedOn").longValue());
+        queryBuilder.append(", '");
+        queryBuilder.append(accountNode.get("status").textValue());
+        queryBuilder.append("')");
+        return queryBuilder.toString();
+    }
+
+    private static String makeInsertIntoAttributesQuery(String accountId, JsonNode attributesNode) {
+        List<String> valueList = new ArrayList<>();
+        Iterator<Map.Entry<String, JsonNode>> attrFieldIter = attributesNode.fields();
+        while (attrFieldIter.hasNext()) {
+            Map.Entry<String, JsonNode> attrFieldEntry = attrFieldIter.next();
+            String attrName = attrFieldEntry.getKey();
+            String attrValue = attrFieldEntry.getValue().textValue();
+            valueList.add("('" + accountId + "', '" + attrName + "', '" + attrValue + "')");
+        }
+
+        return "insert into AccountAttributes (accountId, attributeKey, attributeValue) values " +
+                SQL_VALUES_JOINER.join(valueList);
+    }
+
+    private static int countConsents(JsonNode consentsBySubpop) {
+        if (consentsBySubpop == null || consentsBySubpop.isNull() || consentsBySubpop.size() == 0) {
+            return 0;
+        }
+
+        int numConsents = 0;
+        for (JsonNode consentListForSubpop : consentsBySubpop) {
+            numConsents += consentListForSubpop.size();
+        }
+        return numConsents;
+    }
+
+    private static String makeInsertIntoConsentsQuery(String accountId, JsonNode consentsBySubpopNode) {
+        List<String> valueList = new ArrayList<>();
+        Iterator<Map.Entry<String, JsonNode>> consentsBySubpopIter = consentsBySubpopNode.fields();
+        while (consentsBySubpopIter.hasNext()) {
+            Map.Entry<String, JsonNode> consentsBySubpopEntry = consentsBySubpopIter.next();
+            String subpopGuid = consentsBySubpopEntry.getKey();
+            JsonNode consentListForSubpop = consentsBySubpopEntry.getValue();
+
+            for (JsonNode oneConsent : consentListForSubpop) {
+                StringBuilder valueBuilder = new StringBuilder();
+                valueBuilder.append("('");
+                valueBuilder.append(accountId);
+                valueBuilder.append("', '");
+                valueBuilder.append(subpopGuid);
+                valueBuilder.append("', ");
+                valueBuilder.append(oneConsent.get("signedOn").longValue());
+                valueBuilder.append(", '");
+                valueBuilder.append(oneConsent.get("birthdate").textValue());
+                valueBuilder.append("', ");
+                valueBuilder.append(oneConsent.get("consentCreatedOn").longValue());
+                valueBuilder.append(", '");
+                valueBuilder.append(oneConsent.get("name").textValue());
+                valueBuilder.append("', ");
+                if (oneConsent.has("imageData")) {
+                    valueBuilder.append("'");
+                    valueBuilder.append(oneConsent.get("imageData").textValue());
+                    valueBuilder.append("'");
+                } else {
+                    valueBuilder.append("null");
+                }
+                valueBuilder.append(", ");
+                if (oneConsent.has("imageMimeType")) {
+                    valueBuilder.append("'");
+                    valueBuilder.append(oneConsent.get("imageMimeType").textValue());
+                    valueBuilder.append("'");
+                } else {
+                    valueBuilder.append("null");
+                }
+                valueBuilder.append(", ");
+                if (oneConsent.has("withdrewOn")) {
+                    valueBuilder.append(oneConsent.get("withdrewOn").longValue());
+                } else {
+                    valueBuilder.append("null");
+                }
+                valueBuilder.append(")");
+                valueList.add(valueBuilder.toString());
+            }
+        }
+
+        return "insert into AccountConsents (accountId, subpopulationGuid, signedOn, birthdate, consentCreatedOn, " +
+                "name, signatureImageData, signatureImageMimeType, withdrewOn) values " +
+                SQL_VALUES_JOINER.join(valueList);
+    }
+
+    private static String makeInsertIntoRolesQuery(String accountId, JsonNode roleListNode) {
+        List<String> valueList = new ArrayList<>();
+        for (JsonNode oneRoleNode : roleListNode) {
+            valueList.add("('" + accountId + "', '" + oneRoleNode.textValue() + "')");
+        }
+
+        return "insert into AccountRoles (accountId, role) values " + SQL_VALUES_JOINER.join(valueList);
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/scripts/TransformStormpathAccounts.java
+++ b/src/main/java/org/sagebionetworks/bridge/scripts/TransformStormpathAccounts.java
@@ -177,7 +177,7 @@ public class TransformStormpathAccounts {
 
                     // Max accounts check _after_ the env whitelist. Otherwise, we might waste our "quota" on accounts
                     // that we don't even process.
-                    if (numAccounts >= maxAccounts) {
+                    if (maxAccounts != null && numAccounts >= maxAccounts) {
                         break;
                     }
                     if (numAccounts % LOG_PERIOD == 0) {

--- a/src/main/java/org/sagebionetworks/bridge/scripts/TransformStormpathAccounts.java
+++ b/src/main/java/org/sagebionetworks/bridge/scripts/TransformStormpathAccounts.java
@@ -1,0 +1,355 @@
+package org.sagebionetworks.bridge.scripts;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.GetItemResult;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.RateLimiter;
+import org.apache.commons.lang.StringUtils;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import org.sagebionetworks.bridge.crypto.AesGcmEncryptor;
+import org.sagebionetworks.bridge.crypto.Encryptor;
+
+// Transforms the Stormpath export to an intermediate format, which makes it easier for our scripts to upload
+// everything to MySQL.
+//
+// Pre-req: Run TransformStormpathDirectoriesAndGroups first.
+//
+// To execute:
+// mvn compile exec:java -Dexec.mainClass=org.sagebionetworks.bridge.scripts.TransformStormpathAccounts -Dexec.args=[path to config file]
+public class TransformStormpathAccounts {
+    private static final Map<String, String> BRIDGE_NAME_TO_STORMPATH_NAME_MAP = ImmutableMap.<String, String>builder()
+            .put("id", "id").put("email", "email").put("firstName", "givenName").put("lastName", "surname")
+            .put("status", "status").build();
+    private static final Set<String> CUSTOM_DATA_BLACKLIST = ImmutableSet.of("createdAt", "href", "id", "modifiedAt");
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final DateTimeZone LOCAL_TIME_ZONE = DateTimeZone.forID("America/Los_Angeles");
+    private static final int LOG_PERIOD = 2500;
+
+    // Rate limiter of 10 accounts per second seems reasonable.
+    private static final RateLimiter RATE_LIMITER = RateLimiter.create(10.0);
+
+    private static final Set<String> accountWhitelist = new HashSet<>();
+    private static AmazonDynamoDB ddbClient;
+    private static final Map<String, String> ddbPrefixByEnv = new HashMap<>();
+    private static JsonNode directoriesById;
+    private static final Map<String, Encryptor> encryptorsByEnv = new HashMap<>();
+    private static final Set<String> envSet = new HashSet<>();
+    private static JsonNode groupsByAccountId;
+    private static Integer maxAccounts;
+    private static String stormpathExportRootPath;
+    private static String outputDirPath;
+
+    public static void main(String[] args) throws IOException {
+        // input params
+        if (args.length != 1){
+            System.out.println("Usage: TransformStormpathAccounts [config file]");
+            return;
+        }
+        String configFilePath = args[0];
+
+        // This is to make sure whatever script runs this Java application is properly capturing stdout and stderr and
+        // sending them to the logs
+        System.out.println("Verifying stdout...");
+        System.err.println("Verifying stderr...");
+
+        // init and execute
+        init(configFilePath);
+        loadDirectoriesAndGroups();
+        transformAccounts();
+        cleanup();
+    }
+
+    private static void init(String configFilePath) throws IOException {
+        System.out.println("Initializing...");
+
+        // load config, which is a JSON file
+        JsonNode configNode = JSON_MAPPER.readTree(new File(configFilePath));
+        stormpathExportRootPath = configNode.get("stormpathExportRootPath").textValue();
+        outputDirPath = configNode.get("outputDirPath").textValue();
+
+        // get list of envs
+        JsonNode envListNode = configNode.get("envs");
+        for (JsonNode oneEnvNode : envListNode) {
+            envSet.add(oneEnvNode.textValue());
+        }
+
+        // account whitelist, also used for testing
+        if (configNode.has("accountWhitelist")) {
+            JsonNode accountWhitelistNode = configNode.get("accountWhitelist");
+            for (JsonNode oneAccountId : accountWhitelistNode) {
+                accountWhitelist.add(oneAccountId.textValue());
+            }
+        }
+
+        // maxAccounts. This is used for tests. Since we have over 100k accounts, we don't want to process that many
+        // accounts while testing.
+        if (configNode.has("maxAccounts")) {
+            maxAccounts = configNode.get("maxAccounts").intValue();
+        }
+
+        // init DDB
+        ddbClient = new AmazonDynamoDBClient();
+        JsonNode ddbPrefixByEnvNode = configNode.get("ddbPrefixByEnv");
+        for (String oneEnv : envSet) {
+            String oneDdbPrefix = ddbPrefixByEnvNode.get(oneEnv).textValue();
+            ddbPrefixByEnv.put(oneEnv, oneDdbPrefix);
+        }
+
+        // init encryptors
+        JsonNode encryptionKeysByEnv = configNode.get("encryptionKeysByEnv");
+        for (String oneEnv : envSet) {
+            String oneEncryptionKey = encryptionKeysByEnv.get(oneEnv).textValue();
+            Encryptor oneEncryptor = new AesGcmEncryptor(oneEncryptionKey);
+            encryptorsByEnv.put(oneEnv, oneEncryptor);
+        }
+    }
+
+    public static void cleanup() {
+        ddbClient.shutdown();
+    }
+
+    private static void loadDirectoriesAndGroups() throws IOException {
+        directoriesById = JSON_MAPPER.readTree(Paths.get(outputDirPath, "directoriesById.json").toFile());
+        groupsByAccountId = JSON_MAPPER.readTree(Paths.get(outputDirPath, "groupsByAccountId.json").toFile());
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    private static void transformAccounts() throws IOException {
+        // Create output accounts subdirectory.
+        Path outputAccountsRootPath = Files.createDirectories(Paths.get(outputDirPath, "accounts"));
+
+        // Read accounts from Stormpath dump.
+        int numAccounts = 0;
+        Stopwatch stopwatch = Stopwatch.createStarted();
+        try (Stream<Path> accountPathStream = getPathStream()) {
+            Iterator<Path> accountPathIter = accountPathStream.iterator();
+            while (accountPathIter.hasNext()) {
+                Path oneAccountPath = accountPathIter.next();
+                try {
+                    JsonNode inputAccountNode = JSON_MAPPER.readTree(oneAccountPath.toFile());
+                    ObjectNode outputAccountNode = JSON_MAPPER.createObjectNode();
+                    String accountId = inputAccountNode.get("id").textValue();
+
+                    // Simple attributes
+                    for (Map.Entry<String, String> oneBridgeToStormpathPair : BRIDGE_NAME_TO_STORMPATH_NAME_MAP
+                            .entrySet()) {
+                        String bridgeName = oneBridgeToStormpathPair.getKey();
+                        String stormpathName = oneBridgeToStormpathPair.getValue();
+                        outputAccountNode.set(bridgeName, inputAccountNode.get(stormpathName));
+                    }
+
+                    // get env and study from dirs
+                    String dirId = inputAccountNode.get("directory").get("id").textValue();
+                    JsonNode dirNode = directoriesById.get(dirId);
+                    String env = dirNode.get("env").textValue();
+                    outputAccountNode.put("env", env);
+                    String studyId = dirNode.get("studyId").textValue();
+                    outputAccountNode.put("studyId", studyId);
+
+                    // env whitelist - We have to parse the account first, because Stormpath raw data isn't organized
+                    // by directory.
+                    if (!envSet.contains(env)) {
+                        continue;
+                    }
+
+                    // Max accounts check _after_ the env whitelist. Otherwise, we might waste our "quota" on accounts
+                    // that we don't even process.
+                    if (numAccounts >= maxAccounts) {
+                        break;
+                    }
+                    if (numAccounts % LOG_PERIOD == 0) {
+                        System.out.println(DateTime.now(LOCAL_TIME_ZONE) + ": " + numAccounts +
+                                " accounts processed in " + stopwatch.elapsed(TimeUnit.SECONDS) + " seconds...");
+                    }
+                    numAccounts++;
+
+                    // Similarly, rate limit, also after env whitelist check.
+                    RATE_LIMITER.acquire();
+
+                    // Timestamps in Stormpath are ISO8601 (always UTC). Bridge expects them as epoch milliseconds.
+                    // createdOn
+                    String isoCreatedOnString = inputAccountNode.get("createdAt").textValue();
+                    long createdOnEpochMillis;
+                    if (StringUtils.isNotBlank(isoCreatedOnString)) {
+                        createdOnEpochMillis = DateTime.parse(isoCreatedOnString).getMillis();
+                    } else {
+                        // If Stormpath doesn't know when we created the account, fill in a dummy createdOn timestamp
+                        // (aka now).
+                        createdOnEpochMillis = DateTime.now().getMillis();
+                        System.err.println("ERROR No createdAt found for account " + accountId);
+                    }
+                    outputAccountNode.put("createdOn", createdOnEpochMillis);
+
+                    // modifiedOn
+                    String isoModifiedOnString = inputAccountNode.get("modifiedAt").textValue();
+                    long modifiedOnEpochMillis;
+                    if (StringUtils.isNotBlank(isoModifiedOnString)) {
+                        modifiedOnEpochMillis = DateTime.parse(isoModifiedOnString).getMillis();
+                    } else {
+                        // Similarly, fill this in with createdOn
+                        modifiedOnEpochMillis = createdOnEpochMillis;
+                        System.err.println("ERROR No modifiedAt found for account " + accountId);
+                    }
+                    outputAccountNode.put("modifiedOn", modifiedOnEpochMillis);
+
+                    // passwordModifiedOn (which is required even if passwordHash isn't)
+                    String isoPasswordModifiedOnString = inputAccountNode.get("passwordModifiedAt").textValue();
+                    long passwordModifiedOnEpochMillis;
+                    if (StringUtils.isNotBlank(isoPasswordModifiedOnString)) {
+                        passwordModifiedOnEpochMillis = DateTime.parse(isoPasswordModifiedOnString).getMillis();
+                    } else {
+                        // For whatever reason, most accounts in Stormpath don't have this value filled in. Assume
+                        // that the password has never been changed and fill in with the createdOn.
+                        //
+                        // Also, don't log an error, since this happens more often than not.
+                        passwordModifiedOnEpochMillis = createdOnEpochMillis;
+                    }
+                    outputAccountNode.put("passwordModifiedOn", passwordModifiedOnEpochMillis);
+
+                    // passwords (algorithm, hash, modifiedOn)
+                    String passwordHash = inputAccountNode.get("password").textValue();
+                    if (StringUtils.isNotBlank(passwordHash)) {
+                        // determine algorithm from hash
+                        String passwordAlgorithm = null;
+                        if (passwordHash.startsWith("$stormpath")) {
+                            passwordAlgorithm = "STORMPATH_HMAC_SHA_256";
+                        } else if (passwordHash.startsWith("$2")) {
+                            passwordAlgorithm = "BCRYPT";
+                        } else {
+                            System.err.println("ERROR Cannot identify password algorithm for account " + accountId +
+                                    " password hash " + passwordHash);
+                        }
+                        outputAccountNode.put("passwordAlgorithm", passwordAlgorithm);
+                        outputAccountNode.put("passwordHash", passwordHash);
+                    }
+
+                    // decrypt custom data
+                    Map<String, String> customDataMap = new HashMap<>();
+                    JsonNode customDataNode = inputAccountNode.get("customData");
+                    Iterator<String> customDataFieldNameIter = customDataNode.fieldNames();
+                    while (customDataFieldNameIter.hasNext()) {
+                        String oneFieldName = customDataFieldNameIter.next();
+                        if (CUSTOM_DATA_BLACKLIST.contains(oneFieldName)) {
+                            // metadata fields in Stormpath that we don't need to copy
+                            continue;
+                        }
+                        if (oneFieldName.endsWith("_version")) {
+                            // Encryption version, which we also don't need to copy. Encryption version is always "2"
+                            // anyway (we never had version 1, and we never made version 3), so we don't even need to
+                            // look.
+                            continue;
+                        }
+
+                        // decrypt
+                        String encrypted = customDataNode.get(oneFieldName).textValue();
+                        String decrypted = encryptorsByEnv.get(env).decrypt(encrypted);
+                        customDataMap.put(oneFieldName, decrypted);
+                    }
+
+                    // parse custom data
+                    String healthId = null;
+                    ObjectNode attrMap = JSON_MAPPER.createObjectNode();
+                    ObjectNode consentsBySubpop = JSON_MAPPER.createObjectNode();
+                    for (Map.Entry<String, String> oneCustomData : customDataMap.entrySet()) {
+                        String customDataKey = oneCustomData.getKey();
+                        String customDataValue = oneCustomData.getValue();
+
+                        if (customDataKey.equals(studyId + "_code")) {
+                            healthId = customDataValue;
+                        } else if (customDataKey.endsWith("_consent_signature")) {
+                            // Old-style consent sig (without the plural). We've migrated most, but not all of these.
+                            // If we have a singular consent sig that doesn't also have a list, parse it, wrap it in a
+                            // list, and stick it in the consents map.
+                            if (!customDataMap.containsKey(customDataKey + "s")) {
+                                // extract subpop
+                                String subpopGuid = customDataKey.substring(0, customDataKey.lastIndexOf(
+                                        "_consent_signature"));
+
+                                // parse consent
+                                JsonNode consentNode = JSON_MAPPER.readTree(customDataValue);
+                                ArrayNode consentListNode = JSON_MAPPER.createArrayNode();
+                                consentListNode.add(consentNode);
+                                consentsBySubpop.set(subpopGuid, consentListNode);
+                            }
+                        } else if (customDataKey.endsWith("_consent_signatures")) {
+                            // extract subpop
+                            String subpopGuid = customDataKey.substring(0, customDataKey.lastIndexOf(
+                                    "_consent_signatures"));
+
+                            // parse consent list
+                            JsonNode consentListNode = JSON_MAPPER.readTree(customDataValue);
+                            consentsBySubpop.set(subpopGuid, consentListNode);
+                        } else {
+                            // Anything else is an attribute.
+                            attrMap.put(customDataKey, customDataValue);
+                        }
+                    }
+                    outputAccountNode.put("healthId", healthId);
+                    outputAccountNode.set("consents", consentsBySubpop);
+                    outputAccountNode.set("attributes", attrMap);
+
+                    // get health code from DynamoDB
+                    String healthCode = null;
+                    GetItemResult healthIdResult = ddbClient.getItem(ddbPrefixByEnv.get(env) + "HealthId",
+                            ImmutableMap.of("id", new AttributeValue(healthId)));
+                    Map<String, AttributeValue> healthIdItem = healthIdResult.getItem();
+                    if (healthIdItem == null) {
+                        // This should never happen, but sometimes comes up during testing.
+                        System.err.println("ERROR Couldn't find healthCode for healthId " + healthId + ", accountId " +
+                                accountId + ", env " + env);
+                    } else {
+                        healthCode = healthIdItem.get("code").getS();
+                    }
+                    outputAccountNode.put("healthCode", healthCode);
+
+                    // roles
+                    JsonNode groupList = groupsByAccountId.get(accountId);
+                    outputAccountNode.set("roles", groupList);
+
+                    // write account
+                    JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValue(
+                            outputAccountsRootPath.resolve(accountId + ".json").toFile(), outputAccountNode);
+                } catch (Exception ex) {
+                    System.err.println("ERROR Error processing account file " + oneAccountPath.toString() + ": " +
+                            ex.getMessage());
+                    ex.printStackTrace();
+                }
+            }
+        }
+
+        System.out.println(DateTime.now(LOCAL_TIME_ZONE) + ": " + numAccounts + " accounts processed in " +
+                stopwatch.elapsed(TimeUnit.SECONDS) + " seconds...");
+    }
+
+    private static Stream<Path> getPathStream() throws IOException {
+        if (!accountWhitelist.isEmpty()) {
+            return accountWhitelist.stream().map(accountId -> Paths.get(stormpathExportRootPath, "accounts",
+                    accountId + ".json"));
+        } else {
+            return Files.list(Paths.get(stormpathExportRootPath, "accounts"));
+        }
+    }
+}

--- a/src/main/java/org/sagebionetworks/bridge/scripts/TransformStormpathDirectoriesAndGroups.java
+++ b/src/main/java/org/sagebionetworks/bridge/scripts/TransformStormpathDirectoriesAndGroups.java
@@ -1,0 +1,133 @@
+package org.sagebionetworks.bridge.scripts;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+// Transforms the Stormpath export to an intermediate format, which makes it easier for our scripts to upload
+// everything to MySQL.
+//
+// To execute:
+// mvn compile exec:java -Dexec.mainClass=org.sagebionetworks.bridge.scripts.TransformStormpathDirectoriesAndGroups -Dexec.args=[path to config file]
+public class TransformStormpathDirectoriesAndGroups {
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+    private static final Pattern DIR_NAME_PATTERN = Pattern.compile("(?<studyId>[a-z0-9-]+)\\s+\\((?<env>\\w+)\\)");
+
+    private static String stormpathExportRootPath;
+    private static String outputDirPath;
+
+    public static void main(String[] args) throws IOException {
+        // input params
+        if (args.length != 1){
+            System.out.println("Usage: TransformStormpathDirectoriesAndGroups [config file]");
+            return;
+        }
+        String configFilePath = args[0];
+
+        // This is to make sure whatever script runs this Java application is properly capturing stdout and stderr and
+        // sending them to the logs
+        System.out.println("Verifying stdout...");
+        System.err.println("Verifying stderr...");
+
+        // init and execute
+        init(configFilePath);
+        transformDirectories();
+        transformGroups();
+    }
+
+    private static void init(String configFilePath) throws IOException {
+        System.out.println("Initializing...");
+
+        // load config, which is a JSON file
+        JsonNode configNode = JSON_MAPPER.readTree(new File(configFilePath));
+        stormpathExportRootPath = configNode.get("stormpathExportRootPath").textValue();
+        outputDirPath = configNode.get("outputDirPath").textValue();
+    }
+
+    private static void transformDirectories() throws IOException {
+        // Read directories from Stormpath dump.
+        ObjectNode directoriesById = JSON_MAPPER.createObjectNode();
+        Iterator<Path> dirPathIter = Files.list(Paths.get(stormpathExportRootPath, "directories")).iterator();
+        while (dirPathIter.hasNext()) {
+            Path oneDirPath = dirPathIter.next();
+            JsonNode inputDirNode = JSON_MAPPER.readTree(oneDirPath.toFile());
+            String dirId = inputDirNode.get("id").textValue();
+            String dirName = inputDirNode.get("name").textValue();
+
+            // Parse director name.
+            Matcher dirNameMatcher = DIR_NAME_PATTERN.matcher(dirName);
+            if (dirNameMatcher.matches()) {
+                String studyId = dirNameMatcher.group("studyId");
+                String env = dirNameMatcher.group("env");
+
+                ObjectNode outputDirNode = JSON_MAPPER.createObjectNode();
+                outputDirNode.put("env", env);
+                outputDirNode.put("studyId", studyId);
+                directoriesById.set(dirId, outputDirNode);
+            } else {
+                System.err.println("Could not parse directory with name " + dirName);
+            }
+        }
+
+        // Write to output file.
+        JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValue(Paths.get(outputDirPath, "directoriesById.json")
+                .toFile(), directoriesById);
+    }
+
+    private static void transformGroups() throws IOException {
+        // Read groups from Stormpath dump. Remember, there are a lot of redundant groups, since groups are specific to
+        // directories, while in Bridge, roles are global.
+        Map<String, String> groupsById = new HashMap<>();
+        Iterator<Path> groupPathIter = Files.list(Paths.get(stormpathExportRootPath, "groups")).iterator();
+        while (groupPathIter.hasNext()) {
+            Path oneGroupPath = groupPathIter.next();
+            JsonNode inputGroupNode = JSON_MAPPER.readTree(oneGroupPath.toFile());
+            String groupId = inputGroupNode.get("id").textValue();
+            String groupName = inputGroupNode.get("name").textValue().toUpperCase();
+            groupsById.put(groupId, groupName);
+        }
+
+        // Read group memberships from Stormpath dump. Some accounts have more than one group.
+        Multimap<String, String> groupsByAccountId = HashMultimap.create();
+        Iterator<Path> groupMembershipPathIter = Files.list(Paths.get(stormpathExportRootPath, "groupMemberships"))
+                .iterator();
+        while (groupMembershipPathIter.hasNext()) {
+            Path oneGroupMembershipPath = groupMembershipPathIter.next();
+            JsonNode inputGroupMembershipNode = JSON_MAPPER.readTree(oneGroupMembershipPath.toFile());
+            String accountId = inputGroupMembershipNode.get("account").get("id").textValue();
+            String groupId = inputGroupMembershipNode.get("group").get("id").textValue();
+            groupsByAccountId.put(accountId, groupsById.get(groupId));
+        }
+
+        // Create output JSON.
+        ObjectNode groupsByAccountIdNode = JSON_MAPPER.createObjectNode();
+        for (Map.Entry<String, Collection<String>> groupsForOneAccountId : groupsByAccountId.asMap().entrySet()) {
+            String accountId = groupsForOneAccountId.getKey();
+            Collection<String> groupCol = groupsForOneAccountId.getValue();
+
+            ArrayNode groupListNode = JSON_MAPPER.createArrayNode();
+            groupCol.forEach(groupListNode::add);
+
+            groupsByAccountIdNode.set(accountId, groupListNode);
+        }
+
+        // Write to output file.
+        JSON_MAPPER.writerWithDefaultPrettyPrinter().writeValue(Paths.get(outputDirPath, "groupsByAccountId.json")
+                .toFile(), groupsByAccountIdNode);
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{ISO8601} %-5p [%t] %logger - %message%n%xException%n%mdc</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
Migration scripts for migrating from the Stormpath dump to MySQL-based auth. The two Transform scripts massage the Stormpath dump into temporary JSON, then the Migration script uploads the JSON to MySQL.

Testing done:

Tested Transform scripts. For TransformAccounts, used the maxAccount limit and the accountWhitelist to cherry pick accounts to ensure all columns are hit. Specific test cases include:
* 7QhV5Sy7Xj7ZE0CYtBG5Y6 - attributes
* 6AuHcL6hxcW61ocdARK4Ig - subpop (prod)
* 1a6WYXGWXByTb8tsSXS8l1 - roles
* 10eTDvgqgDaYWRJQsUUNjN - old consent sig (prod)

Created a test account in JSON that has attributes, roles, and multiple consents across multiple subpops. Tested that in the following 4 cases:
* new row
* sql modifiedOn > json modifiedOn (no update)
* sql modifiedOn == json modifiedOn (no update)
* sql modifiedOn < json modifiedOn (yes update, log)

Also verified (by adding extra logging) that the migrated password hash works.