### PR TITLE
fixes and tweaks for Stormpath Migration

### DIFF
--- a/src/main/java/org/sagebionetworks/bridge/scripts/StormpathToMySqlMigration.java
+++ b/src/main/java/org/sagebionetworks/bridge/scripts/StormpathToMySqlMigration.java
@@ -205,7 +205,7 @@ public class StormpathToMySqlMigration {
                             // keep the account info up-to-date. Log, so we can determine how often this is happening
                             // and fix as appropriate.
                             System.out.println("WARN Found outdated account ID " + accountId +
-                                    ", Stormpath account is newer by " + delta + " seconds");
+                                    ", Stormpath account is newer by " + delta + " milliseconds");
 
                             // The result set exists and is older than the JSON account info. Delete the old row and
                             // insert new ones. This is certainly not the most efficient way to update SQL, but this

--- a/src/main/java/org/sagebionetworks/bridge/scripts/StormpathToMySqlMigration.java
+++ b/src/main/java/org/sagebionetworks/bridge/scripts/StormpathToMySqlMigration.java
@@ -192,11 +192,21 @@ public class StormpathToMySqlMigration {
                     }
 
                     if (hasResult) {
-                        if (sqlModifiedOn >= jsonModifiedOn) {
-                            // If the result exists and is up-to-date, skip.
+                        long delta = Math.abs(jsonModifiedOn - sqlModifiedOn);
+                        if (sqlModifiedOn >= jsonModifiedOn || delta < 5000) {
+                            // SQL account is newer than account in Stormpath dump. Alternatively, because of clock
+                            // skew and because we aren't updating both simultaneously, if the SQL account is older,
+                            // but the difference is less than, say, 5 seconds, we consider it up-to-date.
+                            // Skip up-to-date accounts.
                             numSkipped++;
                             continue;
                         } else {
+                            // If we found an outdated row in MySQL, this means our Migration Auth Dao is failing to
+                            // keep the account info up-to-date. Log, so we can determine how often this is happening
+                            // and fix as appropriate.
+                            System.out.println("WARN Found outdated account ID " + accountId +
+                                    ", Stormpath account is newer by " + delta + " seconds");
+
                             // The result set exists and is older than the JSON account info. Delete the old row and
                             // insert new ones. This is certainly not the most efficient way to update SQL, but this
                             // code is simpler than trying to query across 4 tables and figuring out which rows to
@@ -211,18 +221,6 @@ public class StormpathToMySqlMigration {
                                     throw new IllegalStateException("Attempted to delete 1 row for account ID " +
                                             accountId + ", actually deleted " + rowsDeleted);
                                 }
-                            }
-
-                            // If we found an outdated row in MySQL, this means our Migration Auth Dao is failing to
-                            // keep the account info up-to-date. Log, so we can determine how often this is happening
-                            // and fix as appropriate.
-                            long delta = Math.abs(jsonModifiedOn - sqlModifiedOn);
-                            if (delta > 1000) {
-                                // Because accounts aren't updated simultaneously and because of clock skew, Stormpath
-                                // accounts might be slightly newer than MySQL accounts. Only log if the Stormpath
-                                // account is significantly newer (by more than a second).
-                                System.out.println("WARN Found outdated account ID " + accountId +
-                                        ", Stormpath account is newer by " + delta + " seconds");
                             }
 
                             // Metrics


### PR DESCRIPTION
Two changes:

1. Account and CustomData have independent modifiedAt timestamps. This means that if you update CustomData (for example, with an attribute or a consent), the Account.modifiedAt isn't updated. This leads to inaccurate modifiedAt timestamps, which we use to determine whether the MySQL account is up-to-date.

2. Because accounts aren't created/updated simultaneously, and because of clock skew, it is natural for the Stormpath account to be newer by ~1sec. Add a "grace period" of 5 seconds before we consider the account out of date.

Manually tested by importing an account into my local MySQL server and manually tweaking the timestamps.

This isn't urgent. We'll want to run this script one last time in mid-July (after a few weeks of running in Prod) to verify if MySQL and Stormpath diverge, or if we get 0 out-of-date and 0 newly exported accounts from Stormpath to MySQL.